### PR TITLE
feat: don't automatically confirm transactions

### DIFF
--- a/usedispatch_client/src/connection.ts
+++ b/usedispatch_client/src/connection.ts
@@ -42,9 +42,7 @@ export class DispatchConnection {
   }
 
   public async sendTransaction(
-    tx: web3.Transaction,
-    // TODO see if there is a better default than recent
-    commitment: web3.Commitment = 'recent',
+    tx: web3.Transaction
   ) {
     let sig: string;
     if ('sendTransaction' in this.wallet) {
@@ -57,7 +55,6 @@ export class DispatchConnection {
     } else {
       throw new Error('`wallet` has neither `sendTransaction` nor `payer` so cannot send transaction');
     }
-    await this.conn.confirmTransaction(sig, commitment);
     return sig;
   }
 }

--- a/usedispatch_client/src/forum.ts
+++ b/usedispatch_client/src/forum.ts
@@ -247,18 +247,16 @@ export class Forum implements IForum {
 
   async setForumPostRestriction(
     restriction: postbox.PostRestriction,
-    // TODO confirm whether recent is a reasonable default
-    commitment: web3.Commitment = 'recent',
   ): Promise<web3.TransactionSignature> {
-    return this._postbox.setPostboxPostRestriction(restriction, commitment);
+    return this._postbox.setPostboxPostRestriction(restriction);
   }
 
   async setForumPostRestrictionIx(restriction: postbox.PostRestriction): Promise<web3.Transaction> {
     return this._postbox.setPostboxPostRestrictionIx(restriction);
   }
 
-  async deleteForumPostRestriction(commitment: web3.Commitment = 'recent'): Promise<web3.TransactionSignature> {
-    return this._postbox.setPostboxPostRestriction({ null: {} }, commitment);
+  async deleteForumPostRestriction(): Promise<web3.TransactionSignature> {
+    return this._postbox.setPostboxPostRestriction({ null: {} });
   }
 
   async addModerator(newMod: web3.PublicKey): Promise<web3.TransactionSignature> {

--- a/usedispatch_client/src/postbox.ts
+++ b/usedispatch_client/src/postbox.ts
@@ -390,11 +390,9 @@ export class Postbox {
   }
 
   async setPostboxPostRestriction(
-    postRestriction: PostRestriction,
-    // TODO see if there is a better default than recent
-    commitment: web3.Commitment = 'recent',
+    postRestriction: PostRestriction
   ): Promise<web3.TransactionSignature> {
-    return this.innerSetSetting(this._formatPostRestrictionSetting(postRestriction), commitment);
+    return this.innerSetSetting(this._formatPostRestrictionSetting(postRestriction));
   }
 
   async setPostboxPostRestrictionIx(
@@ -415,12 +413,10 @@ export class Postbox {
   }
 
   async innerSetSetting(
-    settingsData: any,
-    // TODO see if there is a better default than recent
-    commitment: web3.Commitment = 'recent',
+    settingsData: any
   ): Promise<web3.TransactionSignature> {
     const ix = await this.innerSetSettingIx(settingsData);
-    return this.dispatch.sendTransaction(ix, commitment);
+    return this.dispatch.sendTransaction(ix);
   }
 
   async innerSetSettingIx(settingsData: any): Promise<web3.Transaction> {


### PR DESCRIPTION
This PR makes it so that the `sendTransaction()` method doesn't automatically confirm transactions. Transaction confirmation can be done elsewhere if the user of this library desires.