### PR TITLE
Delete owner bug

### DIFF
--- a/tests/postbox.ts
+++ b/tests/postbox.ts
@@ -370,7 +370,7 @@ describe('postbox', () => {
     let owners = await forumAsOwner.getOwners();
     assert.equal(owners.length, 1);
     
-    const tx = await forumAsOwner.addOwners([owner.publicKey, user.publicKey]);
+    const tx = await forumAsOwner.setOwners([owner.publicKey, user.publicKey]);
     await conn.confirmTransaction(tx);
 
     owners = await forumAsOwner.getOwners();    

--- a/usedispatch_client/src/forum.ts
+++ b/usedispatch_client/src/forum.ts
@@ -233,8 +233,11 @@ export class Forum implements IForum {
     return this._postbox.getVotes();
   }
 
-  async addOwners(newOwners: web3.PublicKey[]): Promise<web3.TransactionSignature> {
-    const updatedOwners = [...new Set([...(await this.getOwners()), ...newOwners])];
+  async setOwners(newOwners: web3.PublicKey[]): Promise<web3.TransactionSignature> {
+    const updatedOwners = newOwners;
+    if (!newOwners.find(elem => elem.equals(this.dispatchConn.wallet.publicKey))) {
+      updatedOwners.push(this.dispatchConn.wallet.publicKey);
+    }
     return this._postbox.setOwners(updatedOwners);
   }
 


### PR DESCRIPTION
## Description
The list of owners is not being overridden, the function concatenates the array of new owners to the previous list. 


If the original owner list is [A,B,C], and the new list is [A,B], then the resulting list ends up being [A,B,C,A,B]

### Screenshots
![image](https://user-images.githubusercontent.com/47254484/191582120-5f9e95d3-7cc0-4a4f-9008-72333577e2ec.png)
![image](https://user-images.githubusercontent.com/47254484/191581975-1082998d-4140-4c4a-a588-ac32d15af889.png)

