### PR TITLE
Remove max_child_id post check

### DIFF
--- a/programs/postbox/src/lib.rs
+++ b/programs/postbox/src/lib.rs
@@ -78,7 +78,11 @@ pub mod postbox {
         settings: Vec<SettingsData>,
         additional_account_offsets: Vec<AdditionalAccountIndices>,
     ) -> Result<()> {
-        let postbox_account = &mut ctx.accounts.postbox;
+        // Lines commented to allow for arbitary post_id
+        // to be used, enabling multiple posts to be created 
+        // simultaneously using off-chain ID assignment
+
+        // let postbox_account = &mut ctx.accounts.postbox;
         // require!(post_id <= postbox_account.max_child_id + POSTBOX_GROW_CHILDREN_BY, PostboxErrorCode::PostIdTooLarge);
         // if post_id >= postbox_account.max_child_id {
         //     postbox_account.max_child_id += POSTBOX_GROW_CHILDREN_BY;


### PR DESCRIPTION
Accompanies #93 which allows for arbitrary IDs set by the API for post creation.